### PR TITLE
Fix README phrasing

### DIFF
--- a/nomad_project/README.md
+++ b/nomad_project/README.md
@@ -37,7 +37,7 @@ $ crewai run
 
 This command initializes the nomad_project Crew, assembling the agents and assigning them tasks as defined in your configuration.
 
-This example, unmodified, will run the create a `report.md` file with the output of a research on LLMs in the root folder.
+This example, unmodified, will create a `report.md` file with the output of a research on LLMs in the root folder.
 
 ## Understanding Your Crew
 


### PR DESCRIPTION
## Summary
- fix phrasing in the NomadProject README so it references creating the `report.md`

## Testing
- `grep -n "will create" -n nomad_project/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6853b60203448325a006d4fc95f497e2